### PR TITLE
Show that {} is the response

### DIFF
--- a/source/includes/_feed_items.md
+++ b/source/includes/_feed_items.md
@@ -24,6 +24,8 @@ $ http --form POST "https://api.monzo.com/feed" \
     "params[body]=Some body text to display"
 ```
 
+Response:
+
 ```json
 {}
 ```


### PR DESCRIPTION
For too long I'd thought that `{}` was the body of the request.
