### PR TITLE
Add information about `total_balance` value

### DIFF
--- a/source/includes/_balance.md
+++ b/source/includes/_balance.md
@@ -13,6 +13,7 @@ $ http "https://api.monzo.com/balance" \
 ```json
 {
 	"balance": 5000,
+	"total_balance": 6000,
 	"currency": "GBP",
 	"spend_today": 0
 }
@@ -32,5 +33,6 @@ Returns balance information for a specific account.
 <span class="hide">Parameter</span> | <span class="hide">Description</span>
 ------------------------------------|--------------------------------------
 `balance`|The currently available balance of the account, as a 64bit integer in minor units of the currency, eg. pennies for GBP, or cents for EUR and USD.
+`total_balance`|The sum of the currently available balance of the account and the combined total of all [the user's pots](https://monzo.com/docs/#list-pots).
 `currency`|The ISO 4217 currency code.
 `spend_today`|The amount spent from this account today (considered from approx 4am onwards), as a 64bit integer in minor units of the currency.


### PR DESCRIPTION
There has been a bit of confusion in the API Slack channel about the different values and what they marry up to be.

Given James' answer here: https://monzodevelopers.slack.com/archives/C0KP3SB29/p1513949338000264?thread_ts=1513944878000244&cid=C0KP3SB29 - Thought I'd add it to the actual docs to help with the next guy coming along!