### PR TITLE
fixed a few http command examples

### DIFF
--- a/source/includes/_accounts.md
+++ b/source/includes/_accounts.md
@@ -29,5 +29,5 @@ Valid `account_type`s are `uk_retail` and `uk_prepaid`.
 ```shell
 $ http "https://api.monzo.com/accounts" \
     "Authorization: Bearer $access_token" \
-    account_type==uk_retail
+    "account_type=uk_retail"
 ```

--- a/source/includes/_ais.md
+++ b/source/includes/_ais.md
@@ -39,7 +39,7 @@ Only `uk_retail` `account_type`s are visible on the AIS API.
 ```shell
 $ http "https://api.monzo.com/ais/accounts" \
     "Authorization: Bearer $access_token" \
-    account_type==uk_retail
+    "account_type=uk_retail"
 ```
 
 ## Read balance
@@ -49,7 +49,7 @@ Returns a customer's account balance.
 ```shell
 $ http "https://api.monzo.com/ais/balance" \
     "Authorization: Bearer $access_token" \
-    "account_id==$account_id"
+    "account_id=$account_id"
 ```
 
 ```json
@@ -82,7 +82,7 @@ Most properties on transactions are self-explanatory. We'll eventually get aroun
 ```shell
 $ http "https://api.monzo.com/ais/transactions" \
     "Authorization: Bearer $access_token" \
-    "account_id==$account_id"
+    "account_id=$account_id"
 ```
 
 ```json

--- a/source/includes/_balance.md
+++ b/source/includes/_balance.md
@@ -7,7 +7,7 @@ Retrieve information about an account's balance.
 ```shell
 $ http "https://api.monzo.com/balance" \
     "Authorization: Bearer $access_token" \
-    "account_id==$account_id"
+    "account_id=$account_id"
 ```
 
 ```json

--- a/source/includes/_transactions.md
+++ b/source/includes/_transactions.md
@@ -21,7 +21,7 @@ Most properties on transactions are self-explanatory. We'll eventually get aroun
 $ http "https://api.monzo.com/transactions/$transaction_id" \
     "Authorization: Bearer $access_token" \
     # Here we are expanding the merchant \
-    "expand[]==merchant"
+    "expand[]=merchant"
 ```
 
 ```json
@@ -73,7 +73,7 @@ Returns an individual transaction, fetched by its id.
 ```shell
 $ http "https://api.monzo.com/transactions" \
     "Authorization: Bearer $access_token" \
-    "account_id==$account_id"
+    "account_id=$account_id"
 ```
 
 ```json

--- a/source/includes/_webhooks.md
+++ b/source/includes/_webhooks.md
@@ -35,7 +35,7 @@ Each time a matching event occurs, we will make a POST call to the URL you provi
 ```shell
 $ http "https://api.monzo.com/webhooks" \
     "Authorization: Bearer $access_token" \
-    "account_id==$account_id"
+    "account_id=$account_id"
 ```
 
 ```json


### PR DESCRIPTION
Some of the key value pairs within example http commands were separated by == instead of = also added a few quotes for consistency.