### PR TITLE
add listing pots to the documented ais api

### DIFF
--- a/source/includes/_ais.md
+++ b/source/includes/_ais.md
@@ -121,3 +121,29 @@ Returns a list of transactions on the user's account.
 ------------------------------------|--------------------------------------
 `account_id`<br><span class="label notice">Required</span>|The account to retrieve transactions from.
 Pagination<br><span class="label">Optional</span>|This endpoint can be [paginated](#pagination).
+
+## List pots
+
+```shell
+$ http "https://api.monzo.com/ais/pots" \
+    "Authorization: Bearer $access_token"
+```
+
+```json
+{
+  "pots": [
+    {
+      "id": "pot_0000778xxfgh4iu8z83nWb",
+      "name": "Savings",
+      "style": "beach_ball",
+      "balance": 133700,
+      "currency": "GBP",
+      "created": "2017-11-09T12:30:53.695Z",
+      "updated": "2017-11-09T12:30:53.695Z",
+      "deleted": false
+    }
+  ]
+}
+```
+
+Returns a list of pots owned by the currently authorised user.


### PR DESCRIPTION
Adds /ais/pots to the documented ais endpoint

![image](https://user-images.githubusercontent.com/1209874/39056867-b62cb61a-44af-11e8-95b1-f85f7050eafd.png)
