### PR TITLE
Updated list of `decline_reason` values

### DIFF
--- a/source/includes/_transactions.md
+++ b/source/includes/_transactions.md
@@ -9,7 +9,7 @@ Most properties on transactions are self-explanatory. We'll eventually get aroun
 <span class="hide">Property</span> | <span class="hide">Description</span>
 -----------------------------------|--------------------------------------
 `amount`         | The amount of the transaction in minor units of `currency`. For example pennies in the case of GBP. A negative amount indicates a debit (most card transactions will have a negative amount)
-`decline_reason` | **This is only present on declined transactions!** Valid values are `INSUFFICIENT_FUNDS`, `CARD_INACTIVE`, `CARD_BLOCKED` or `OTHER`.
+`decline_reason` | **This is only present on declined transactions!** Valid values are `INSUFFICIENT_FUNDS`, `CARD_INACTIVE`, `CARD_BLOCKED`, `INVALID_CVC` or `OTHER`.
 `is_load`        | Top-ups to an account are represented as transactions with a positive amount and `is_load = true`. Other transactions such as refunds, reversals or chargebacks may have a positive amount but `is_load = false`
 `settled`        | The timestamp at which the transaction settled. In most cases, this happens 24-48 hours after `created`. If this field is not present, the transaction is authorised but not yet "complete."
 `category`       | The category can be set for each transaction by the user. Over time we learn which merchant goes in which category and auto-assign the category of a transaction. If the user hasn't set a category, we'll return the default category of the merchant on this transactions. Top-ups have category `mondo`. Valid values are `general`, `eating_out`, `expenses`, `transport`, `cash`, `bills`, `entertainment`, `shopping`, `holidays`, `groceries`.


### PR DESCRIPTION
I suspect there might be more values missing from this list. What about invalid expiry date and invalid PIN?