### PR TITLE
Add dynamic client registration info

### DIFF
--- a/source/includes/_ais.md
+++ b/source/includes/_ais.md
@@ -5,8 +5,7 @@ and more for our customers in the United Kingdom.
 
 ## Getting Access
 
-The Open Banking team at Monzo manage access to the Account Information Services API. To get in touch, email us at 
-[openbanking@monzo.com](mailto:openbanking@monzo.com).
+To get access to our Open Banking APIs, see the **Dynamic Client Registration** section below.
 
 ## Well-Known Endpoints
 
@@ -29,6 +28,12 @@ We've included the Base URLs for our Sandbox and Production environments below.
 ------------------------------------|--------------------------------------
 Sandbox | `https://openbanking.s101.nonprod-ffs.io/open-banking/v3.1/aisp`
 Production | `https://openbanking.monzo.com/open-banking/v3.1/aisp`
+
+## Dynamic Client Registration
+
+We have implemented version 3.2 of the Open Banking Dynamic Client Registration specification. You can find the [full specification here](https://openbanking.atlassian.net/wiki/spaces/DZ/pages/1078034771/Dynamic+Client+Registration+-+v3.2).
+
+You can find the appropriate URL and supported configuration in our well-known endpoints for each environment.
 
 ## Authentication
 
@@ -249,3 +254,8 @@ The <code>Data/SupplementaryData</code> object in an Account Consent request is 
 specification, but we accept it specifically in the Sandbox environment to mirror how we allow consent automatic 
 approval in the Payment Initiation API.
 </aside>
+
+## Additional Help
+
+The Open Banking team at Monzo manage the Account Information Services API. If you require additional assistance, email us at 
+[openbanking@monzo.com](mailto:openbanking@monzo.com).

--- a/source/includes/_ais.md
+++ b/source/includes/_ais.md
@@ -31,7 +31,7 @@ Production | `https://openbanking.monzo.com/open-banking/v3.1/aisp`
 
 ## Dynamic Client Registration
 
-We have implemented version 3.2 of the Open Banking Dynamic Client Registration specification. You can find the [full specification here](https://openbanking.atlassian.net/wiki/spaces/DZ/pages/1078034771/Dynamic+Client+Registration+-+v3.2).
+We have implemented the `POST /register` endpoint in version 3.2 of the Open Banking Dynamic Client Registration specification. You can find the [full specification here](https://openbanking.atlassian.net/wiki/spaces/DZ/pages/1078034771/Dynamic+Client+Registration+-+v3.2).
 
 You can find the appropriate URL and supported configuration in our well-known endpoints for each environment.
 

--- a/source/includes/_cbpii.md
+++ b/source/includes/_cbpii.md
@@ -5,8 +5,7 @@ enough money for a purchase.
 
 ## Getting Access
 
-The Open Banking team at Monzo manage access to the Confirmation of Funds API. To get in touch, email us at 
-[openbanking@monzo.com](mailto:openbanking@monzo.com).
+To get access to our Open Banking APIs, see the **Dynamic Client Registration** section below.
 
 ## Well-Known Endpoints
 
@@ -28,6 +27,12 @@ We've included the Base URLs for our Sandbox and Production environments below.
 Sandbox | `https://openbanking.s101.nonprod-ffs.io/open-banking/v3.1/cbpii`
 Production | `https://openbanking.monzo.com/open-banking/v3.1/cbpii`
 
+## Dynamic Client Registration
+
+We have implemented version 3.2 of the Open Banking Dynamic Client Registration specification. You can find the [full specification here](https://openbanking.atlassian.net/wiki/spaces/DZ/pages/1078034771/Dynamic+Client+Registration+-+v3.2).
+
+You can find the appropriate URL and supported configuration in our well-known endpoints for each environment.
+
 ## Authentication
 As per the Open Banking specification, we use OAuth 2 and OpenID connect for authentication. We have implemented the 
 redirect flow, with authentication taking place in the customer's Monzo app.
@@ -48,3 +53,8 @@ Monzo will apply Strong Customer Authentication the first time we authenticate a
 (CBPII) consents. Since access is limited to information about the customer's balance, consents can be ongoing 
 and do <b>not</b> require the customer to regularly re-authenticate.
 </aside>
+
+## Additional Help
+
+The Open Banking team at Monzo manage the Confirmation of Funds API. If you require additional assistance, email us at 
+[openbanking@monzo.com](mailto:openbanking@monzo.com).

--- a/source/includes/_cbpii.md
+++ b/source/includes/_cbpii.md
@@ -29,7 +29,7 @@ Production | `https://openbanking.monzo.com/open-banking/v3.1/cbpii`
 
 ## Dynamic Client Registration
 
-We have implemented version 3.2 of the Open Banking Dynamic Client Registration specification. You can find the [full specification here](https://openbanking.atlassian.net/wiki/spaces/DZ/pages/1078034771/Dynamic+Client+Registration+-+v3.2).
+We have implemented the `POST /register` endpoint in version 3.2 of the Open Banking Dynamic Client Registration specification. You can find the [full specification here](https://openbanking.atlassian.net/wiki/spaces/DZ/pages/1078034771/Dynamic+Client+Registration+-+v3.2).
 
 You can find the appropriate URL and supported configuration in our well-known endpoints for each environment.
 

--- a/source/includes/_pis.md
+++ b/source/includes/_pis.md
@@ -30,7 +30,7 @@ Production | `https://openbanking.monzo.com/open-banking/v3.1/pisp`
 
 ## Dynamic Client Registration
 
-We have implemented version 3.2 of the Open Banking Dynamic Client Registration specification. You can find the [full specification here](https://openbanking.atlassian.net/wiki/spaces/DZ/pages/1078034771/Dynamic+Client+Registration+-+v3.2).
+We have implemented the `POST /register` endpoint in version 3.2 of the Open Banking Dynamic Client Registration specification. You can find the [full specification here](https://openbanking.atlassian.net/wiki/spaces/DZ/pages/1078034771/Dynamic+Client+Registration+-+v3.2).
 
 You can find the appropriate URL and supported configuration in our well-known endpoints for each environment.
 

--- a/source/includes/_pis.md
+++ b/source/includes/_pis.md
@@ -6,8 +6,7 @@ API are sent through Faster Payments.
 
 ## Getting Access
 
-The Open Banking team at Monzo manage access to the Account Information Services API. To get in touch, email us at 
-[openbanking@monzo.com](mailto:openbanking@monzo.com).
+To get access to our Open Banking APIs, see the **Dynamic Client Registration** section below.
 
 ## Well-Known Endpoints
 
@@ -28,6 +27,12 @@ We've included the Base URLs for our Sandbox and Production environments below.
 ------------------------------------|--------------------------------------
 Sandbox | `https://openbanking.s101.nonprod-ffs.io/open-banking/v3.1/pisp`
 Production | `https://openbanking.monzo.com/open-banking/v3.1/pisp`
+
+## Dynamic Client Registration
+
+We have implemented version 3.2 of the Open Banking Dynamic Client Registration specification. You can find the [full specification here](https://openbanking.atlassian.net/wiki/spaces/DZ/pages/1078034771/Dynamic+Client+Registration+-+v3.2).
+
+You can find the appropriate URL and supported configuration in our well-known endpoints for each environment.
 
 ## Authentication
 
@@ -116,3 +121,8 @@ If you want your payment to come from a specific User and Account then you can a
   "AccountID": "account_000yyy"
 }
 ```
+
+## Additional Help
+
+The Open Banking team at Monzo manage the Payment Initiation Services API. If you require additional assistance, email us at 
+[openbanking@monzo.com](mailto:openbanking@monzo.com).


### PR DESCRIPTION
I've kept the Getting Access section as it's the most-likely question people will ask, and they may not necessarily have the patience to read down to `Dynamic Client Registration`. 

I've also shunted our email address all the way to the bottom, it _may_ help reduce inbound and promote self-service