### PR TITLE
update dockerfile to not use deprecated flags

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu
 
 RUN apt-get update
 RUN apt-get install -yq ruby-full ruby-dev build-essential git
-RUN gem install -v 1.17.3 --no-ri --no-rdoc bundler
+RUN gem install -v 1.17.3 --no-document bundler
 ADD Gemfile /app/Gemfile
 ADD Gemfile.lock /app/Gemfile.lock
 RUN cd /app && bundle install --system

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -145,4 +145,4 @@ DEPENDENCIES
   therubyracer (~> 0.12.2)
 
 BUNDLED WITH
-   1.17.1
+   2.1.4

--- a/README.md
+++ b/README.md
@@ -32,3 +32,7 @@ Need help? Found a bug?
 -----------------------
 
 Just [submit an issue](https://github.com/monzo/docs/issues) to this GitHub repo if you need any help. And, of course, feel free to submit pull requests with bug fixes or changes.
+
+Deploying changes
+----------------------
+Follow the deployment guide [here](https://www.notion.so/monzo/Deploying-Monzo-API-Docs-f18f80a4b12d4811af83c4aa6a77dfe2)


### PR DESCRIPTION
updates to help deployment:
- update dockerfile to run locally: `--no-ri` and `--no-rdoc` have been updated to `--no-document`
- update bundler version
- add deployment doc
