### PR TITLE
publish `v3.1.10` now SCA-RTS changes are live

### DIFF
--- a/source/includes/_ais.md
+++ b/source/includes/_ais.md
@@ -82,7 +82,7 @@ We only support the `tls_client_auth` authentication method.
 }
 ```
 
-We've implemented version 3.1.9 of the [Open Banking accounts specification](https://openbankinguk.github.io/read-write-api-site3/v3.1.9/resources-and-data-models/aisp/Accounts.html).
+We've implemented version 3.1.10 of the [Open Banking accounts specification](https://openbankinguk.github.io/read-write-api-site3/v3.1.10/resources-and-data-models/aisp/Accounts.html).
 
 Once you have a consent for a customer, you'll be able to see their:
 
@@ -101,7 +101,7 @@ or `ReadAccountsDetail` permission. In the former case, we will omit the account
 
 ## Balances
 
-We've implemented version 3.1.9 of the [Open Banking balances specification](https://openbankinguk.github.io/read-write-api-site3/v3.1.9/resources-and-data-models/aisp/Balances.html).
+We've implemented version 3.1.10 of the [Open Banking balances specification](https://openbankinguk.github.io/read-write-api-site3/v3.1.10/resources-and-data-models/aisp/Balances.html).
 
 When you query this endpoint, you'll see the customer's `InterimAvailable` balance. This is the same real-time balance 
 that our customers see in the Monzo app, and it includes pending and settled transactions.
@@ -146,7 +146,7 @@ that our customers see in the Monzo app, and it includes pending and settled tra
 }
 ```
 
-We've implemented version 3.1.9 of the [Open Banking transactions specification](https://openbankinguk.github.io/read-write-api-site3/v3.1.9/resources-and-data-models/aisp/Transactions.html).
+We've implemented version 3.1.10 of the [Open Banking transactions specification](https://openbankinguk.github.io/read-write-api-site3/v3.1.10/resources-and-data-models/aisp/Transactions.html).
 
 For consistency with our internal systems and the rest of our API, you will need to provide the start and end times in 
 [**RFC3339 format**](https://www.ietf.org/rfc/rfc3339.txt).
@@ -169,7 +169,7 @@ This status will begin to be returned from the AIS API on the 25th of September 
 
 ## Parties
 
-We've implemented version 3.1.9. of the [Open Banking parties specification](https://openbankinguk.github.io/read-write-api-site3/v3.1.9/resources-and-data-models/aisp/Parties.html)
+We've implemented version 3.1.10. of the [Open Banking parties specification](https://openbankinguk.github.io/read-write-api-site3/v3.1.10/resources-and-data-models/aisp/Parties.html)
 
 We have implemented the `GET /party` and `GET /accounts/{accountId}/party` endpoints for reading details of the consent authoriser and `GET /accounts/{accountId}/parties` for reading the details of all account holders/owners. These endpoints return the IDs, preferred names, and legal names of account holders/owners.
 
@@ -272,7 +272,7 @@ any more.
 
 ## Direct Debits
 
-We've implemented version 3.1.9 of the [Open Banking Direct Debits specification](https://openbankinguk.github.io/read-write-api-site3/v3.1.9/resources-and-data-models/aisp/direct-debits.html).
+We've implemented version 3.1.10 of the [Open Banking Direct Debits specification](https://openbankinguk.github.io/read-write-api-site3/v3.1.10/resources-and-data-models/aisp/direct-debits.html).
 
 We have only implemented `GET /accounts/{AccountId}/direct-debits` endpoint.
 
@@ -286,7 +286,7 @@ access Direct Debits that were collected within the last 90 days.
 
 ## Scheduled Payments
 
-We've implemented version 3.1.9 of the [Open Banking Scheduled Payments specification](https://openbankinguk.github.io/read-write-api-site3/v3.1.9/resources-and-data-models/aisp/scheduled-payments.html).
+We've implemented version 3.1.10 of the [Open Banking Scheduled Payments specification](https://openbankinguk.github.io/read-write-api-site3/v3.1.10/resources-and-data-models/aisp/scheduled-payments.html).
 
 We have only implemented `GET /accounts/{AccountId}/scheduled-payments` endpoint.
 
@@ -300,7 +300,7 @@ You can access all scheduled payments as long as the customer has completed Stro
 
 ## Standing Orders
 
-We've implemented version 3.1.9 of the [Open Banking Standing Orders specification](https://openbankinguk.github.io/read-write-api-site3/v3.1.9/resources-and-data-models/aisp/standing-orders.html).
+We've implemented version 3.1.10 of the [Open Banking Standing Orders specification](https://openbankinguk.github.io/read-write-api-site3/v3.1.10/resources-and-data-models/aisp/standing-orders.html).
 
 We have only implemented `GET /accounts/{AccountId}/standing-orders` endpoint.
 

--- a/source/includes/_cbpii.md
+++ b/source/includes/_cbpii.md
@@ -40,7 +40,7 @@ redirect flow, with authentication taking place in the customer's Monzo app.
 We only support the `tls_client_auth` authentication method.
 
 ## Confirmation of Funds
-We have implemented version 3.1.9 of the [Open Banking Confirmation of Funds Specification](https://openbankinguk.github.io/read-write-api-site3/v3.1.9/profiles/confirmation-of-funds-api-profile.html).
+We have implemented version 3.1.10 of the [Open Banking Confirmation of Funds Specification](https://openbankinguk.github.io/read-write-api-site3/v3.1.10/profiles/confirmation-of-funds-api-profile.html).
 
 We use the **redirection flow** for approving consents.
 

--- a/source/includes/_pis.md
+++ b/source/includes/_pis.md
@@ -46,7 +46,7 @@ have one hour.
 
 ## Domestic Payments
 
-We've implemented version 3.1.9 of the [Open Banking Domestic Payments specification](https://openbankinguk.github.io/read-write-api-site3/v3.1.9/resources-and-data-models/pisp/domestic-payments.html).
+We've implemented version 3.1.10 of the [Open Banking Domestic Payments specification](https://openbankinguk.github.io/read-write-api-site3/v3.1.10/resources-and-data-models/pisp/domestic-payments.html).
 
 When you request a consent for Domestic Payments, you should provide `UK.OBIE.FPS` as the `LocalInstrument`.
 
@@ -57,7 +57,7 @@ You can only make payments in `GBP`. We don't support other currencies.
 
 ## Scheduled Payments
 
-We've implemented version 3.1.9 of the [Open Banking Scheduled Payments specification](https://openbankinguk.github.io/read-write-api-site3/v3.1.9/resources-and-data-models/aisp/scheduled-payments.html).
+We've implemented version 3.1.10 of the [Open Banking Scheduled Payments specification](https://openbankinguk.github.io/read-write-api-site3/v3.1.10/resources-and-data-models/aisp/scheduled-payments.html).
 
 For consistency with our internal systems and the rest of our API, you will need to provide times in **RFC3339 format.**
 
@@ -76,7 +76,7 @@ All of our scheduled payments are sent in the early hours of the morning on the 
 
 ## Standing Orders
 
-We have implemented version 3.1.9 of the [Open Banking Standing Order specification](https://openbankinguk.github.io/read-write-api-site3/v3.1.9/resources-and-data-models/aisp/standing-orders.html).
+We have implemented version 3.1.10 of the [Open Banking Standing Order specification](https://openbankinguk.github.io/read-write-api-site3/v3.1.10/resources-and-data-models/aisp/standing-orders.html).
 
 For consistency with our internal systems and the rest of our API, you will need to provide times in **RFC3339 format.**
 


### PR DESCRIPTION
Now that the changes for SCA-RTS PS21/19 are live the docs can be updated to reflect v3.1.10