### PR TITLE
Added a notice for listing transactions regarding supported account t…

### DIFF
--- a/source/includes/_transactions.md
+++ b/source/includes/_transactions.md
@@ -116,6 +116,9 @@ After a user has authenticated, your client can fetch all of their transactions,
 If you need the user’s entire transaction history, you should consider fetching and storing it right after authentication.
 </aside>
 
+<aside class="notice">
+The list transactions API currently only supports transactions for Current Accounts and Flex Accounts.
+</aside>
 
 ##### Request arguments
 


### PR DESCRIPTION
The list transactions API behaves in the following fashion depending upon the account type:

Current Account - Lists as expected
Loan - Returns an empty list of transactions
Flex Backing Load - Returns a 403 Forbidden response
Flex - Lists as expected

After contacting support I have been advised that Loan and Flex Backing Loan are not supported byt the endpoint.