### PR TITLE
OB:  update PIS documentation about error returned in case of insufficient funds

### DIFF
--- a/source/includes/_pis.md
+++ b/source/includes/_pis.md
@@ -55,6 +55,10 @@ We support account identification using `UK.OBIE.SortCodeAccountNumber`. We don'
 
 You can only make payments in `GBP`. We don't support other currencies.
 
+<aside class="notice">
+If there are insufficient funds in the account, the error on redirection is returned with the code `access_denied` and description "Insufficient funds in selected account to make requested payment."
+</aside>
+
 ## Scheduled Payments
 
 We've implemented version 3.1.10 of the [Open Banking Scheduled Payments specification](https://openbankinguk.github.io/read-write-api-site3/v3.1.10/resources-and-data-models/aisp/scheduled-payments.html).

--- a/source/includes/_pis.md
+++ b/source/includes/_pis.md
@@ -56,7 +56,7 @@ We support account identification using `UK.OBIE.SortCodeAccountNumber`. We don'
 You can only make payments in `GBP`. We don't support other currencies.
 
 <aside class="notice">
-If there are insufficient funds in the account, authorisation will fail and an error will be returned on redirection with the code `access_denied` and description "Insufficient funds in selected account to make requested payment."
+If there are insufficient funds in the account, authorisation will fail and an error will be returned on redirection with the code `access_denied` and `error_description` being "Insufficient funds in selected account to make requested payment."
 </aside>
 
 ## Scheduled Payments

--- a/source/includes/_pis.md
+++ b/source/includes/_pis.md
@@ -56,7 +56,7 @@ We support account identification using `UK.OBIE.SortCodeAccountNumber`. We don'
 You can only make payments in `GBP`. We don't support other currencies.
 
 <aside class="notice">
-If there are insufficient funds in the account, the error on redirection is returned with the code `access_denied` and description "Insufficient funds in selected account to make requested payment."
+If there are insufficient funds in the account, authorisation will fail and an error will be returned on redirection with the code `access_denied` and description "Insufficient funds in selected account to make requested payment."
 </aside>
 
 ## Scheduled Payments


### PR DESCRIPTION
Update Payment Initiation Services API - Domestic payment docs on redirection error returned in case of insufficient funds.