### PR TITLE
Remove link to deleted blog post

### DIFF
--- a/source/index.html.md
+++ b/source/index.html.md
@@ -45,7 +45,7 @@ The [Developers category](https://community.monzo.com/c/developers) on our forum
 
 <aside class="warning">
     <strong>The Monzo Developer API is not suitable for building public applications.</strong><br>
-    You may only connect to your own account or those of a small set of users you explicitly allow. Please read our <a href="https://monzo.com/blog/2017/05/11/api-update/">blog post</a> for more detail.
+    You may only connect to your own account or those of a small set of users you explicitly allow.
 </aside>
 
 <aside class="warning">


### PR DESCRIPTION
The blog post mentioned in this text has been deleted and the link goes to a 404.