### PR TITLE
Remove google analytics UA from layout

### DIFF
--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -140,14 +140,5 @@ under the License.
         <% end %>
       </div>
     </div>
-    <!-- Google Analytics -->
-    <script>
-      (function(b,o,i,l,e,r){b.GoogleAnalyticsObject=l;b[l]||(b[l]=
-      function(){(b[l].q=b[l].q||[]).push(arguments)});b[l].l=+new Date;
-      e=o.createElement(i);r=o.getElementsByTagName(i)[0];
-      e.src='//www.google-analytics.com/analytics.js';
-      r.parentNode.insertBefore(e,r)}(window,document,'script','ga'));
-      ga('create','UA-63104269-1');ga('send','pageview');
-    </script>
   </body>
 </html>


### PR DESCRIPTION
Remove Google Analytics Universal Analytics.

[Google analytics UA](https://support.google.com/analytics/answer/11583528?hl=en) was sunsetted on July 1, 2024.